### PR TITLE
Fix multi-line history for zsh

### DIFF
--- a/shell/parser.go
+++ b/shell/parser.go
@@ -44,8 +44,9 @@ func ParseZshHistory() []string {
 
 	for i, v := range historySlice {
 		if strings.HasPrefix(v, ":") { //check if there is a timestamp and remove it
-			commandSlice := strings.Split(v, ";")
-			historySlice[i] = commandSlice[1]
+			if idx := strings.Index(v, ";"); idx >= 0 {
+				historySlice[i] = historySlice[i][idx+1:]
+			}
 		}
 	}
 


### PR DESCRIPTION
a missing boundary check for multi-line commands can cause a panic in
the history parser. Example input:

       : 1614496050:0;vi ~/.zsh_history\
       : q

This commit removes the timestamp prefix only if a matching
semicolon was found.

Note, although this commit fixes the panic, multi-lines are still counted as
individual commands.